### PR TITLE
fix paths from hello-world to cms-react

### DIFF
--- a/cms-react-theme/layouts/base.hubl.html
+++ b/cms-react-theme/layouts/base.hubl.html
@@ -18,7 +18,7 @@
     <div class="body-wrapper {{ builtin_body_classes }}">
       {% block header %}
         {% js_partial
-          path="@projects/hello-world-project/hello-world-app/components/partials/Header.jsx",
+          path="@projects/cms-react-project/cms-react-app/components/partials/Header.jsx",
           brandColor="{{ theme.brand_color }}",
           text="Hello from HubL!",
           no_wrapper=True %}
@@ -31,7 +31,7 @@
 
       {% block footer %}
         {% js_partial
-          path="@projects/hello-world-project/hello-world-app/components/partials/Footer.jsx",
+          path="@projects/cms-react-project/cms-react-app/components/partials/Footer.jsx",
           no_wrapper=True %}
       {% endblock footer %}
     </div>


### PR DESCRIPTION
## Overview:

Current code in `base.hubl.html` creates a fail in the build process when running `npm run upload:hubl`

### Suggestion:

Consider updating the paths in the `base.hubl.html` file to `cms-react` rather than `hello-world`

### Reason:

Would make it easier and more intuitive for new users to follow the _A Quickstart Guide to React in the CMS_ course in HubSpot Academy.